### PR TITLE
Provide customerid in case no args is passed to API call

### DIFF
--- a/nodeping.php
+++ b/nodeping.php
@@ -138,6 +138,9 @@ class NodePingRequest{
             //$dataarray = array_map('NodePingRequest::jsonize', $dataarray);
             $query = '?'.http_build_query($queryarray);
             //error_log('Query is: '.print_r($query, true));
+        }elseif($this->config['customerid']){
+            $queryarray = array('customerid'=>$this->config['customerid']);
+            $query = '?'.http_build_query($queryarray);
         }
         $url = $this->config['apiurl'].'/'.$this->config['apiversion'].'/'.$this->resource.$query;
         //error_log('URL is: '.print_r($url, true));


### PR DESCRIPTION
This was missed in https://github.com/NodePing/NodePing_php/pull/3.

We could have calls like `$api_client->check->get()` which does not have `dataarray` but we still need the `customerid`.